### PR TITLE
Turn caching back on

### DIFF
--- a/app/vysledky/[id]/page.tsx
+++ b/app/vysledky/[id]/page.tsx
@@ -49,3 +49,8 @@ async function getResult(id: string): Promise<Result | null> {
       return null;
     });
 }
+
+/** Force incremental static generation (ISR), see https://github.com/cesko-digital/web/issues/987 */
+export async function generateStaticParams() {
+  return [];
+}


### PR DESCRIPTION
We will only merge this before launch, it’s easier to develop without cache.